### PR TITLE
GitHub crawling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A curated list of awesome MATLAB toolboxes, applications, software and resources
   - [Image Processing and Computer Vision](#image-processing-and-computer-vision)
   - [Model Reduction](#model-reduction)
   - [Interfacing with other languages](#interfacing-with-other-languages)
+  - [Interfacing with other programs](#interfacing-with-other-programs)
   - [Learning MATLAB](#learning-matlab)
   - [Making Figures](#making-figures)
   - [MATLAB-like environments](#matlab-like-environments)
@@ -92,6 +93,12 @@ A curated list of awesome MATLAB toolboxes, applications, software and resources
 * [Python](http://uk.mathworks.com/help/matlab/call-python-libraries.html) - How to call Python functions from within MATLAB.
 * [matlab kernel](https://github.com/calysto/matlab_kernel) - To run MATLAB code inside IPython / Jupyter notebooks.
 * [octave kernel](https://github.com/calysto/octave_kernel) - To run Octave code inside IPython / Jupyter notebooks.
+
+
+## Interfacing with other programs
+
+* [MATLAB QuickLook](https://github.com/jaketmp/matlab-quicklook) - QuickLook preview generator for MAT files. This shows the contents of your MAT files in Finder. The binary is only compatible with 64 bit OS X.
+
 
 ## Learning MATLAB
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ A curated list of awesome MATLAB toolboxes, applications, software and resources
 
 * [MATLAB QuickLook](https://github.com/jaketmp/matlab-quicklook) - QuickLook preview generator for MAT files. This shows the contents of your MAT files in Finder. The binary is only compatible with 64 bit OS X.
 * [MATLAB-git](https://github.com/manur/MATLAB-git) - A thin wrapper to call `git` from within a MATLAB console.
+* [JSONlab](https://github.com/fangq/jsonlab) - Toolbox to encode/decode [JSON](http://www.json.org) data files from within MATLAB and Octave.
 
 
 ## Learning MATLAB

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ A curated list of awesome MATLAB toolboxes, applications, software and resources
 * [MatConvNet](http://www.vlfeat.org/matconvnet/) - MatConvNet is a free MATLAB toolbox implementing Convolutional Neural Networks (CNNs) for computer vision applications. It is simple, efficient, and can run and learn state-of-the-art CNNs. It provides pre-trained CNNs for image classification, segmentation, face recognition, and text detection.
 * [Piotr's Image and Video Toolbox](https://github.com/pdollar/toolbox) - This free toolbox facilitates the manipulation of images and video in MATLAB. Its purpose is to complement, not replace, MATLAB's Image Processing Toolbox.
 * [VLFeat](http://www.vlfeat.org/) - The VLFeat free and open source library implements popular computer vision algorithms specializing in image understanding and local features extraction and matching. It is written in C for efficiency and compatibility, with interfaces in MATLAB for ease of use, and detailed documentation throughout.
+* [MexOpenCV](https://github.com/kyamagu/mexopencv) - MATLAB MEX interface for [OpenCV](http://opencv.org), i.e. one of the leading libraries for computer vision.
 
 ## Model Reduction
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ A curated list of awesome MATLAB toolboxes, applications, software and resources
 ## Interfacing with other programs
 
 * [MATLAB QuickLook](https://github.com/jaketmp/matlab-quicklook) - QuickLook preview generator for MAT files. This shows the contents of your MAT files in Finder. The binary is only compatible with 64 bit OS X.
+* [MATLAB-git](https://github.com/manur/MATLAB-git) - A thin wrapper to call `git` from within a MATLAB console.
 
 
 ## Learning MATLAB


### PR DESCRIPTION
This fixes #15.
I have gone over the first 20 or so github search pages (see #15), what I thought was useful I added (if we didn't have it already). Everything ranked lower, I think, is probably not awesome (and if it is, it will eventually make it's way here, I suspect).
- MATLAB-git, is something I use myself (older version and tweaked by myself, I think), and it is also awesome.
- JSONlab, I tried it out once for Trendy, it is very useful.
- MexOpenCV, I cannot certify myself, but I think the stars don't lie.

Also, MATLAB QuickLook is something I found today: this is really needed for people on a Mac.
