### PR TITLE
Remove Uiextras GUI framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,6 @@ Inspired by [awesome-R](https://github.com/qinwf/awesome-R).
 * [UQLab](http://www.uqlab.com/) - The Framework for Uncertainty Quantification.
 * [Octave Forge](http://octave.sourceforge.net/) - Extra packages for GNU Octave.
 * [Matrix Computation Toolbox](http://www.maths.manchester.ac.uk/~higham/mctoolbox/) - for constructing test matrices, computing matrix factorizations, visualizing matrices, and carrying out direct search optimization.
-* [Uiextras GUI framework](https://github.com/precisesimulation/matlab-octave-gui-layout-toolbox) - GUI layout framework - cross compatible with both Octave and Matlab.
 * [GRANSO](http://timmitchell.com/software/GRANSO/index.html) - GRadient-based Algorithm for Non-Smooth Optimization.
 * [CAAM 551](http://www.caam.rice.edu/~caam551/MatlabCode/matlabcode.html) - Advanced Numerical Linear Algebra.
 * [EliteQuant](https://github.com/EliteQuant/EliteQuant_Matlab) - Unified quantitative backtesting and live trading platform.


### PR DESCRIPTION
As for 23 March 2018, the link to Uiextras GUI framework is broken. The linked repository is either deleted or set private.